### PR TITLE
Implement fuzzy/nearest color matching in image_to_data

### DIFF
--- a/place_bot/color.py
+++ b/place_bot/color.py
@@ -82,7 +82,14 @@ class Color(Enum):
         return [int(hex[2*i:2*i+2], base=16) for i in range(3)]
 
     @staticmethod
-    def from_pixel(rgb_im_px) -> 'Color':
+    def from_pixel(rgb_im_pix: list[int]) -> 'Color':
+        color = Color.exact_from_pixel(rgb_im_pix)
+        if color is None:
+            color = Color.closest_from_pixel(rgb_im_pix)
+        return color
+
+    @staticmethod
+    def exact_from_pixel(rgb_im_px: list[int]) -> 'Color':
         r, g, b = rgb_im_px
         hex_ = Color.rgb2hex(r, g, b)
         return _PIXEL_MAP.get(hex_.upper().strip("#"))

--- a/place_bot/place_bot.py
+++ b/place_bot/place_bot.py
@@ -160,14 +160,15 @@ class Placer:
         return differing_pixels
 
     @staticmethod
-    def image_to_data(image: Image, shape: Tuple[int, int], indexed_color=False):
+    def image_to_data(image: Image, shape: Tuple[int, int], indexed_color=False, fuzzy=False):
         if indexed_color:
             data = np.array(image.getdata())
 
             # all color indices are off by 1
             data = data - 1
         else:
-            data = np.array([Color.from_pixel(px).value.id for px in image.getdata()])
+            from_pixel = Color.from_pixel if not fuzzy else Color.closest_from_pixel
+            data = np.array([from_pixel(px).value.id for px in image.getdata()])
 
         data = np.reshape(data, shape)
         return data

--- a/place_bot/place_bot.py
+++ b/place_bot/place_bot.py
@@ -160,15 +160,14 @@ class Placer:
         return differing_pixels
 
     @staticmethod
-    def image_to_data(image: Image, shape: Tuple[int, int], indexed_color=False, fuzzy=False):
+    def image_to_data(image: Image, shape: Tuple[int, int], indexed_color=False):
         if indexed_color:
             data = np.array(image.getdata())
 
             # all color indices are off by 1
             data = data - 1
         else:
-            from_pixel = Color.from_pixel if not fuzzy else Color.closest_from_pixel
-            data = np.array([from_pixel(px).value.id for px in image.getdata()])
+            data = np.array([Color.from_pixel(px).value.id for px in image.getdata()])
 
         data = np.reshape(data, shape)
         return data

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="PlaceBot",
-    version="0.1.0",
+    version="0.2.0",
     packages=["place_bot"],
     install_requires=[
         "requests",


### PR DESCRIPTION
As @laundmo mentioned in #4, it would be nice if colors in `image_to_data` were determined by the "nearest" color.

This PR implements this feature based on the ordinary Euclidean distance in RGB space (probably not the best possible metric but it should do for a start).

It's slower than it needs to be because only the iteration over palette colors is implemented in terms of NumPy array operations while the loop that goes over pixels is still pure Python. It wouldn't be difficult to change this but let's start with this because it's easier to read and doesn't require any refactoring of the surrounding code to make it look nice.